### PR TITLE
fix: build won't break when a generic relation is used

### DIFF
--- a/strawberry_django_plus/type.py
+++ b/strawberry_django_plus/type.py
@@ -191,9 +191,9 @@ def _from_django_type(
             if isinstance(model_field, GenericRel):
                 description = None
             elif isinstance(model_field, (ManyToOneRel, ManyToManyRel)):
-                description = model_field.help_text
-            else:
                 description = model_field.field.help_text
+            else:
+                description = model_field.help_text
             if description:
                 field.description = str(description)
 

--- a/strawberry_django_plus/type.py
+++ b/strawberry_django_plus/type.py
@@ -15,6 +15,7 @@ from typing import (
 )
 
 from django.core.exceptions import FieldDoesNotExist
+from django.contrib.contenttypes.fields import GenericRel
 from django.db.models.base import Model
 from django.db.models.fields.reverse_related import ManyToManyRel, ManyToOneRel
 import strawberry
@@ -187,11 +188,14 @@ def _from_django_type(
             )
 
         if field.description is None:
-            description = (
-                model_field.field.help_text
-                if isinstance(model_field, (ManyToOneRel, ManyToManyRel))
-                else model_field.help_text
-            )
+            if isinstance(model_field, GenericRel):
+                description = None
+            elif isinstance(model_field, (ManyToOneRel, ManyToManyRel)):
+                description = model_field.help_text
+            else:
+                description = (
+                    model_field.field.help_text
+                )
             if description:
                 field.description = str(description)
 

--- a/strawberry_django_plus/type.py
+++ b/strawberry_django_plus/type.py
@@ -14,8 +14,8 @@ from typing import (
     get_origin,
 )
 
-from django.core.exceptions import FieldDoesNotExist
 from django.contrib.contenttypes.fields import GenericRel
+from django.core.exceptions import FieldDoesNotExist
 from django.db.models.base import Model
 from django.db.models.fields.reverse_related import ManyToManyRel, ManyToOneRel
 import strawberry
@@ -193,9 +193,7 @@ def _from_django_type(
             elif isinstance(model_field, (ManyToOneRel, ManyToManyRel)):
                 description = model_field.help_text
             else:
-                description = (
-                    model_field.field.help_text
-                )
+                description = model_field.field.help_text
             if description:
                 field.description = str(description)
 


### PR DESCRIPTION
```
  File ".../venv/lib/python3.9/site-packages/strawberry_django_plus/type.py", line 375, in wrapper
    return _process_type(
  File ".../venv/lib/python3.9/site-packages/strawberry_django_plus/type.py", line 264, in _process_type
    fields = list(_get_fields(django_type).values())
  File ".../venv/lib/python3.9/site-packages/strawberry_django_plus/type.py", line 211, in _get_fields
    fields[name] = _from_django_type(
  File ".../venv/lib/python3.9/site-packages/strawberry_django_plus/type.py", line 193, in _from_django_type
    else model_field.help_text
AttributeError: 'GenericRel' object has no attribute 'help_text'
```

This will avoid the above issue