### PR TITLE
feat: Apply get_queryset when resolving Django relay.Node types

### DIFF
--- a/demo/schema.py
+++ b/demo/schema.py
@@ -40,6 +40,19 @@ class UserType(relay.Node):
         return f"{root.first_name or ''} {root.last_name or ''}".strip()
 
 
+@gql.django.type(UserModel)
+class StaffType(relay.Node):
+    username: gql.auto
+    email: gql.auto
+    is_active: gql.auto
+    is_superuser: gql.auto
+    is_staff: gql.auto
+
+    @classmethod
+    def get_queryset(cls, queryset: QuerySet[UserModel], info: Info) -> QuerySet[UserModel]:
+        return queryset.filter(is_staff=True)
+
+
 @gql.django.type(Project)
 class ProjectType(relay.Node):
     name: gql.auto
@@ -167,6 +180,8 @@ class Query:
     milestones: List[MilestoneType] = gql.django.node()
     project: Optional[ProjectType] = gql.django.node()
     tag: Optional[TagType] = gql.django.node()
+    staff: Optional[StaffType] = gql.django.node()
+    staff_list: List[StaffType] = gql.django.node()
 
     issue_list: List[IssueType] = gql.django.field()
     milestone_list: List[MilestoneType] = gql.django.field(
@@ -184,6 +199,7 @@ class Query:
 
     project_conn: relay.Connection[ProjectType] = gql.django.connection()
     tag_conn: relay.Connection[TagType] = gql.django.connection()
+    staff_conn: relay.Connection[StaffType] = gql.django.connection()
 
     # Login required to resolve
     issue_login_required: IssueType = gql.django.node(directives=[IsAuthenticated()])

--- a/strawberry_django_plus/field.py
+++ b/strawberry_django_plus/field.py
@@ -313,6 +313,9 @@ class StrawberryDjangoConnectionField(relay.ConnectionField, StrawberryDjangoFie
         if nodes is None:
             nodes = self.model._default_manager.all()
 
+            if self.origin_django_type and hasattr(self.origin_django_type.origin, "get_queryset"):
+                nodes = self.origin_django_type.origin.get_queryset(nodes, info)
+
         return resolvers.resolve_result(
             nodes,
             info=info,

--- a/strawberry_django_plus/utils/resolvers.py
+++ b/strawberry_django_plus/utils/resolvers.py
@@ -330,6 +330,10 @@ def resolve_model_nodes(
         source = cast(Type[_M], django_type.model)
 
     qs = source._default_manager.all()
+
+    if hasattr(django_type.origin, "get_queryset"):
+        qs = django_type.origin.get_queryset(qs, info)
+
     if node_ids is not None:
         qs = qs.filter(pk__in=[i.node_id if isinstance(i, GlobalID) else i for i in node_ids])
 
@@ -393,6 +397,9 @@ def resolve_model_node(source, node_id, *, info: Optional[Info] = None, required
         node_id = node_id.node_id
 
     qs = source._default_manager.filter(pk=node_id)
+
+    if hasattr(django_type.origin, "get_queryset"):
+        qs = django_type.origin.get_queryset(qs, info)
 
     if required:
         ret = resolve_result(qs, info=info, qs_resolver=resolve_qs_get_one)
@@ -474,6 +481,9 @@ def resolve_connection(
 
         nodes = source._default_manager.all()
         assert isinstance(nodes, QuerySet)
+
+        if hasattr(django_type.origin, "get_queryset"):
+            nodes = django_type.origin.get_queryset(nodes, info)
 
     if is_awaitable(nodes, info=info):
         return resolve_async(

--- a/tests/data/schema.gql
+++ b/tests/data/schema.gql
@@ -390,6 +390,14 @@ type Query {
     """The ID of the object."""
     id: GlobalID!
   ): TagType
+  staff(
+    """The ID of the object."""
+    id: GlobalID!
+  ): StaffType
+  staffList(
+    """The IDs of the objects."""
+    ids: [GlobalID!]!
+  ): [StaffType!]!
   issueList: [IssueType!]!
   milestoneList(pagination: OffsetPaginationInput, filters: MilestoneFilter, order: MilestoneOrder): [MilestoneType!]!
   projectList: [ProjectType!]!
@@ -448,6 +456,19 @@ type Query {
     """Returns the items in the list that come after the specified cursor."""
     last: Int = null
   ): TagTypeConnection!
+  staffConn(
+    """Returns the items in the list that come before the specified cursor."""
+    before: String = null
+
+    """Returns the items in the list that come after the specified cursor."""
+    after: String = null
+
+    """Returns the first n items from the list."""
+    first: Int = null
+
+    """Returns the items in the list that come after the specified cursor."""
+    last: Int = null
+  ): StaffTypeConnection!
   issueLoginRequired(
     """The ID of the object."""
     id: GlobalID!
@@ -531,6 +552,48 @@ type Query {
     last: Int = null
     name: String!
   ): ProjectTypeConnection!
+}
+
+type StaffType implements Node {
+  id: GlobalID!
+
+  """Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only."""
+  username: String!
+  email: String!
+
+  """
+  Designates whether this user should be treated as active. Unselect this instead of deleting accounts.
+  """
+  isActive: Boolean!
+
+  """
+  Designates that this user has all permissions without explicitly assigning them.
+  """
+  isSuperuser: Boolean!
+
+  """Designates whether the user can log into this admin site."""
+  isStaff: Boolean!
+}
+
+"""A connection to a list of items."""
+type StaffTypeConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [StaffTypeEdge!]!
+
+  """Total quantity of existing nodes"""
+  totalCount: Int!
+}
+
+"""An edge in a connection."""
+type StaffTypeEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: StaffType!
 }
 
 """An enumeration."""


### PR DESCRIPTION
Applies `get_queryset` method when resolving nodes and connection as discussed in #43 .

Tests misses change in `utils.resolvers.resolve_connection`. It's not called in tests with `nodes = None` now. And I don't know how to setup this use case.

Closes #43 