### PR TITLE
fix: Fix optimizer sentinel being ignored for prefetch

### DIFF
--- a/strawberry_django_plus/optimizer.py
+++ b/strawberry_django_plus/optimizer.py
@@ -463,9 +463,9 @@ class OptimizerStore:
 
                 p1 = PrefetchInspector(existing)
                 p2 = PrefetchInspector(p)
-                if getattr(existing, "_sentinel", None) is _sentinel:
+                if getattr(existing, "_optimizer_sentinel", None) is _sentinel:
                     ret = p1.merge(p2, allow_unsafe_ops=True)
-                elif getattr(p, "_sentinel", None) is _sentinel:
+                elif getattr(p, "_optimizer_sentinel", None) is _sentinel:
                     ret = p2.merge(p1, allow_unsafe_ops=True)
                 else:
                     # The order here doesn't matter

--- a/strawberry_django_plus/utils/inspect.py
+++ b/strawberry_django_plus/utils/inspect.py
@@ -294,7 +294,7 @@ class PrefetchInspector:
 
     @prefetch_related.setter
     def prefetch_related(self, value: Optional[Iterable[Union[Prefetch, str]]]):
-        self.query.select_related = tuple(value or [])  # type:ignore
+        self.qs._prefetch_related_lookups = tuple(value or [])  # type:ignore
 
     @property
     def annotations(self) -> Dict[str, Expression]:
@@ -333,12 +333,12 @@ class PrefetchInspector:
         # Merge only/deferred
         if not allow_unsafe_ops and (self.defer is None) != (other.defer is None):
             raise ValueError(
-                "Tried to prefetch 2 queries with with different deferred "
+                "Tried to prefetch 2 queries with different deferred "
                 "operations. Use only `only` or `deferred`, not both..."
             )
-        if self.only and other.only:
+        if self.only is not None and other.only is not None:
             self.only = self.only | other.only
-        elif self.defer and other.defer:
+        elif self.defer is not None and other.defer is not None:
             self.defer = self.defer | other.defer
         else:
             # One has defer, the other only. In this case, defer nothing


### PR DESCRIPTION
Figured this out due to this:

https://github.com/blb-ventures/strawberry-django-plus/blob/1b6fdeed91e2bbc7b22366379ba7351f4ec4ff8c/strawberry_django_plus/utils/inspect.py#L334-L338

What stroke me as odd, was that `self.defer` was `None` and `other.defer` was empty frozenset(). Shouldn't the condition be adjusted for that as those values represent the same thing in this case?