### PR TITLE
fix: fix missing export of django_resolver

### DIFF
--- a/strawberry_django_plus/gql/django.py
+++ b/strawberry_django_plus/gql/django.py
@@ -7,6 +7,7 @@ from strawberry_django import (
     OneToManyInput,
     OneToOneInput,
     auth,
+    django_resolver,
     filters,
     ordering,
 )
@@ -24,6 +25,7 @@ from strawberry_django_plus.type import input, interface, partial, type
 __all__ = [
     # strawberry_django
     "auth",
+    "django_resolver",
     "filters",
     "ordering",
     "DjangoFileType",


### PR DESCRIPTION
# What
you lack an re-export of django_resolver (used for cross compatibility sync required resolvers, e.g. ORM)