### PR TITLE
Replace cast with int

### DIFF
--- a/strawberry_django_plus/relay.py
+++ b/strawberry_django_plus/relay.py
@@ -669,7 +669,7 @@ class Connection(Generic[NodeType]):
         if total_count is None:
             # Support ORMs that define .count() (e.g. django)
             try:
-                total_count = int(nodes.count())
+                total_count = int(nodes.count())  # type:ignore
             except (AttributeError, ValueError, TypeError):
                 if isinstance(nodes, Sized):
                     total_count = len(nodes)

--- a/strawberry_django_plus/relay.py
+++ b/strawberry_django_plus/relay.py
@@ -666,9 +666,9 @@ class Connection(Generic[NodeType]):
             https://relay.dev/graphql/connections.htm#sec-Pagination-algorithm
 
         """
-        if total_count is None:            
+        if total_count is None:
             # Support ORMs that define .count() (e.g. django)
-            try:                        
+            try:
                 total_count = int(nodes.count())
             except (AttributeError, ValueError, TypeError):
                 if isinstance(nodes, Sized):

--- a/strawberry_django_plus/relay.py
+++ b/strawberry_django_plus/relay.py
@@ -666,11 +666,11 @@ class Connection(Generic[NodeType]):
             https://relay.dev/graphql/connections.htm#sec-Pagination-algorithm
 
         """
-        if total_count is None:
-            try:
-                # Support ORMs that define .count() (e.g. django)
-                total_count = cast(int, nodes.count())  # type:ignore
-            except (AttributeError, TypeError):
+        if total_count is None:            
+            # Support ORMs that define .count() (e.g. django)
+            try:                        
+                total_count = int(nodes.count())
+            except (AttributeError, ValueError, TypeError):
                 if isinstance(nodes, Sized):
                     total_count = len(nodes)
                 else:


### PR DESCRIPTION
I think this is what was intended? The except TypeError won't happen with cast() because it doesn't try to change the runtime type.