### PR TITLE
pass `kwargs` down to `check_condition`

### DIFF
--- a/strawberry_django_plus/permissions.py
+++ b/strawberry_django_plus/permissions.py
@@ -261,6 +261,7 @@ class AuthDirective(SchemaDirectiveWithResolver):
                     resolver,
                     root,
                     info,
+                    **kwargs,
                 ),
                 info=info,
             )
@@ -373,16 +374,17 @@ class ConditionDirective(AuthDirective):
         root: Any,
         info: GraphQLResolveInfo,
         user: UserType,
+        **kwargs,
     ):
         return self.resolve_retval(
             helper,
             root,
             info,
             resolver,
-            self.check_condition(root, info, user),
+            self.check_condition(root, info, user, **kwargs),
         )
 
-    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType):
+    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType, **kwargs):
         raise NotImplementedError
 
 
@@ -396,7 +398,7 @@ class IsAuthenticated(ConditionDirective):
 
     message: Private[str] = dataclasses.field(default="User is not authenticated.")
 
-    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType):
+    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType, **kwargs):
         return user.is_authenticated and user.is_active
 
 
@@ -410,7 +412,7 @@ class IsStaff(ConditionDirective):
 
     message: Private[str] = dataclasses.field(default="User is not a staff member.")
 
-    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType):
+    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType, **kwargs):
         return user.is_authenticated and user.is_staff
 
 
@@ -424,7 +426,7 @@ class IsSuperuser(ConditionDirective):
 
     message: Private[str] = dataclasses.field(default="User is not a superuser.")
 
-    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType):
+    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType, **kwargs):
         return user.is_authenticated and user.is_superuser
 
 

--- a/strawberry_django_plus/permissions.py
+++ b/strawberry_django_plus/permissions.py
@@ -261,6 +261,7 @@ class AuthDirective(SchemaDirectiveWithResolver):
                     resolver,
                     root,
                     info,
+                    **kwargs,
                 ),
                 info=info,
             )
@@ -271,6 +272,7 @@ class AuthDirective(SchemaDirectiveWithResolver):
             root,
             info,
             cast(UserType, user),
+            **kwargs,
         )
 
     def resolve_for_user(
@@ -280,6 +282,7 @@ class AuthDirective(SchemaDirectiveWithResolver):
         root: Any,
         info: GraphQLResolveInfo,
         user: UserType,
+        **kwargs,
     ):
         raise NotImplementedError
 
@@ -373,16 +376,17 @@ class ConditionDirective(AuthDirective):
         root: Any,
         info: GraphQLResolveInfo,
         user: UserType,
+        **kwargs,
     ):
         return self.resolve_retval(
             helper,
             root,
             info,
             resolver,
-            self.check_condition(root, info, user),
+            self.check_condition(root, info, user, **kwargs),
         )
 
-    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType):
+    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType, **kwargs):
         raise NotImplementedError
 
 
@@ -396,7 +400,7 @@ class IsAuthenticated(ConditionDirective):
 
     message: Private[str] = dataclasses.field(default="User is not authenticated.")
 
-    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType):
+    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType, **kwargs):
         return user.is_authenticated and user.is_active
 
 
@@ -410,7 +414,7 @@ class IsStaff(ConditionDirective):
 
     message: Private[str] = dataclasses.field(default="User is not a staff member.")
 
-    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType):
+    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType, **kwargs):
         return user.is_authenticated and user.is_staff
 
 
@@ -424,7 +428,7 @@ class IsSuperuser(ConditionDirective):
 
     message: Private[str] = dataclasses.field(default="User is not a superuser.")
 
-    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType):
+    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType, **kwargs):
         return user.is_authenticated and user.is_superuser
 
 
@@ -586,6 +590,7 @@ class HasPermDirective(AuthDirective):
         root: Any,
         info: GraphQLResolveInfo,
         user: UserType,
+        **kwargs,
     ):
         if self.with_superuser and user.is_active and user.is_superuser:
             return self.resolve_retval(helper, root, info, resolver, True)

--- a/strawberry_django_plus/permissions.py
+++ b/strawberry_django_plus/permissions.py
@@ -261,7 +261,6 @@ class AuthDirective(SchemaDirectiveWithResolver):
                     resolver,
                     root,
                     info,
-                    **kwargs,
                 ),
                 info=info,
             )
@@ -374,17 +373,16 @@ class ConditionDirective(AuthDirective):
         root: Any,
         info: GraphQLResolveInfo,
         user: UserType,
-        **kwargs,
     ):
         return self.resolve_retval(
             helper,
             root,
             info,
             resolver,
-            self.check_condition(root, info, user, **kwargs),
+            self.check_condition(root, info, user),
         )
 
-    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType, **kwargs):
+    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType):
         raise NotImplementedError
 
 
@@ -398,7 +396,7 @@ class IsAuthenticated(ConditionDirective):
 
     message: Private[str] = dataclasses.field(default="User is not authenticated.")
 
-    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType, **kwargs):
+    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType):
         return user.is_authenticated and user.is_active
 
 
@@ -412,7 +410,7 @@ class IsStaff(ConditionDirective):
 
     message: Private[str] = dataclasses.field(default="User is not a staff member.")
 
-    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType, **kwargs):
+    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType):
         return user.is_authenticated and user.is_staff
 
 
@@ -426,7 +424,7 @@ class IsSuperuser(ConditionDirective):
 
     message: Private[str] = dataclasses.field(default="User is not a superuser.")
 
-    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType, **kwargs):
+    def check_condition(self, root: Any, info: GraphQLResolveInfo, user: UserType):
         return user.is_authenticated and user.is_superuser
 
 


### PR DESCRIPTION
fixes #70 .
it passes the `kwargs` from `resolve` in `AuthDirective` class to `resolve_for_user` then to `check_condition`.

so that overriding the method `check_condition` gives access to the query variables 