### PR TITLE
docs: fix link to django-guardian docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ for information on how to use this lib.
   using schema directives, supporting both
   [django authentication system](https://docs.djangoproject.com/en/4.0/topics/auth/default/),
   direct and per-object permission checking for backends that implement those (e.g.
-  [django-guardian](https://django-guardian.readthedocs.io/en/stable])).
+  [django-guardian](https://django-guardian.readthedocs.io/en/stable/)).
 - [Mutations for Django](https://blb-ventures.github.io/strawberry-django-plus/quickstart/#django-mutations),
   with CRUD support and automatic errors validation.
 - [Relay support](https://blb-ventures.github.io/strawberry-django-plus/quickstart/#relay-support)


### PR DESCRIPTION
This pull request fixes a link to the `django-guardian` docs in the README