### PR TITLE
fix(optimizer): avoid double add_prefix calls

### DIFF
--- a/strawberry_django_plus/optimizer.py
+++ b/strawberry_django_plus/optimizer.py
@@ -432,7 +432,6 @@ class OptimizerStore:
             if isinstance(p, Callable):
                 assert_type(p, PrefetchCallable)
                 p = p(info)
-                p.add_prefix(prefix)
 
             if isinstance(p, str):
                 prefetch_related.append(f"{prefix}{LOOKUP_SEP}{p}")


### PR DESCRIPTION
I think I've found the root cause of the issue explained in #98.

I believe this add_prefix call should not be there, since it's also added in the elif here:
https://github.com/blb-ventures/strawberry-django-plus/blob/2c2d142a30cebcbd901b60290f6fcd3d6b51bfc9/strawberry_django_plus/optimizer.py#L439
on the resulting Prefetch.