### PR TITLE
Support for custom Globally Unique ID field name

### DIFF
--- a/strawberry_django_plus/settings.py
+++ b/strawberry_django_plus/settings.py
@@ -23,6 +23,7 @@ class Config:
     """
 
     RELAY_MAX_RESULTS: Optional[int] = dataclasses.field(default=100)
+    RELAY_GLOBAL_ID_FIELD_NAME: str = dataclasses.field(default="id")
     REMOVE_DUPLICATED_SUFFIX: List[str] = dataclasses.field(
         default_factory=lambda: ["Input", "Partial"],
     )


### PR DESCRIPTION
According to https://relay.dev/docs/guides/graphql-server-specification/#object-identification the Node interface should have a field named `id` with the Globally Unique ID. However, for simpler APIs it can be beneficial to have the name of this field customized to expose the raw object id under the field `id`, and the global id under a different name (e.g. `global_id`).

This is achieved by using a metaclass for the Node abstract class which defines the field according to the value of `config.RELAY_GLOBAL_ID_FIELD_NAME`.

---

**Known issues**

1. The value of `config.RELAY_GLOBAL_ID_FIELD_NAME` is always passed to `to_camel_case`, so the strawberry's `auto_camel_case` configuration is ignored.
2. Any library relying on the id field being named `id` won't work (but I guess this should be fine since this is an opt-in settings clearly conflicting with relay libraries).
3. It uses meta-programming, which may not make IDEs super happy.
4. A test is not passing because somehow this changes the behavior of the printer for the `Node` interface.

**More info about the failed test**

Previously the generated schema had the description comment only at the definition of the interface, while the types implementing the interface had the field undocumented.

<details>
<summary>Previously</summary>

```graphql
"""An object with a Globally Unique ID"""
interface Node {
  """The Globally Unique ID of this object"""
  id: GlobalID!
}

type ProjectType implements Node {
  id: GlobalID!

  """The name of the project"""
  name: String!
}
```

</details>

Now every instance of the _derived_ id field also includes the docstring.


<details>
<summary>Now</summary>

```graphql
"""An object with a Globally Unique ID"""
interface Node {
  """The Globally Unique ID of this object"""
  id: GlobalID!
}

type ProjectType implements Node {
  """The Globally Unique ID of this object"""
  id: GlobalID!

  """The name of the project"""
  name: String!
}
```

</details>

I'm clueless on why, and I'm not even sure if this matters (is it a good practice to not include the docstring of implemented interfaces?). If this is ok, I can update the schema used for the tests and make the last test pass.

---

CC: #57 