### PR TITLE
Fix pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         args: ["--py38-plus"]
 
   - repo: https://github.com/myint/docformatter
-    rev: v1.5.0-rc1
+    rev: v1.5.0
     hooks:
       - id: docformatter
         args: ["-i", "--wrap-summaries", "0", "--blank"]


### PR DESCRIPTION
The v1.5.0-rc1 tag has been replaced by the v1.5.0 at:
https://github.com/PyCQA/docformatter/tags

Without this installing the pre-commit hooks fail with:

```
[INFO] Initializing environment for https://github.com/myint/docformatter.
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/git', 'checkout', 'v1.5.0-rc1')
return code: 1
expected return code: 0
stdout: (none)
stderr:
    error: pathspec 'v1.5.0-rc1' did not match any file(s) known to git
```