### PR TITLE
Feat: Customizable typename; Fix: GlobalID parse_literal,  UNSET as default_value 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         args: ["--py38-plus"]
 
   - repo: https://github.com/myint/docformatter
-    rev: v1.5.0-rc1
+    rev: v1.5.0
     hooks:
       - id: docformatter
         args: ["-i", "--wrap-summaries", "0", "--blank"]

--- a/strawberry_django_plus/type.py
+++ b/strawberry_django_plus/type.py
@@ -201,9 +201,12 @@ def _from_django_type(
             if description:
                 field.description = str(description)
 
-    # FIXME: How to properly workaround this for mutations?
-    if django_type.is_input and field.default_value is UNSET:
-        field.default = UNSET
+    if (
+        django_type.is_input
+        and field.default_value is UNSET
+        and field.default_factory is dataclasses.MISSING
+    ):
+        field.default_factory = lambda: UNSET
 
     return field
 


### PR DESCRIPTION
Ads capability to customize typename for Node.
Fixes parse_literal parameters to match graphql parse_literal for GlobalID  
"Fixes" current implementation of default value of UNSET to use default_factory instead of default_value

