### PR TITLE
[#134] Add `is_basic_field` to `RelayField`

### DIFF
--- a/strawberry_django_plus/relay.py
+++ b/strawberry_django_plus/relay.py
@@ -797,6 +797,10 @@ class RelayField(StrawberryField):
         }
         return list(args.values())
 
+    @cached_property
+    def is_basic_field(self):
+        return False
+
     @functools.cached_property
     def is_optional(self):
         return isinstance(self.type, StrawberryOptional)
@@ -840,10 +844,6 @@ class NodeField(RelayField):
                     description="The ID of the object.",
                 ),
             }
-
-    @cached_property
-    def is_basic_field(self):
-        return False
 
     def __call__(self, resolver):
         raise TypeError("NodeField cannot have a resolver, use a common field instead.")


### PR DESCRIPTION
This moves the `is_basic_field` implementation from `NodeField` to `RelayField`. This allows it to cover `ConnectionField` as well. Previously, top-level connection fields would crash when queried because of the missing `is_basic_field` implementation. I was experiencing this issue in my app, and after this change, the issue is gone.

Fix #134