### PR TITLE
fix: Make auto-type field in filter optional (as in strawberry_django)

### DIFF
--- a/strawberry_django_plus/type.py
+++ b/strawberry_django_plus/type.py
@@ -25,7 +25,11 @@ from strawberry.types.fields.resolver import StrawberryResolver
 from strawberry.unset import UnsetType
 from strawberry.utils.typing import __dataclass_transform__
 from strawberry_django.fields.field import field as _field
-from strawberry_django.fields.types import get_model_field, resolve_model_field_name
+from strawberry_django.fields.types import (
+    get_model_field,
+    is_optional,
+    resolve_model_field_name,
+)
 from strawberry_django.type import StrawberryDjangoType as _StraberryDjangoType
 from strawberry_django.utils import get_annotations, is_similar_django_type
 from typing_extensions import Annotated
@@ -194,6 +198,9 @@ def _from_django_type(
 
             if description:
                 field.description = str(description)
+
+        if is_optional(model_field, django_type.is_input, django_type.is_partial):
+            field.type_annotation.annotation = Optional[field.type_annotation.annotation]
 
     return field
 

--- a/strawberry_django_plus/type.py
+++ b/strawberry_django_plus/type.py
@@ -187,6 +187,9 @@ def _from_django_type(
             field.type_annotation = StrawberryAnnotation(
                 resolve_model_field_type(model_field, django_type)
             )
+        # Force non-auto filters fields to be optional
+        elif is_optional(model_field, django_type.is_input, django_type.is_partial):
+            field.type_annotation = StrawberryAnnotation(Optional[field.type_annotation.annotation])
 
         if field.description is None:
             if isinstance(model_field, (GenericRel, GenericForeignKey)):
@@ -198,9 +201,6 @@ def _from_django_type(
 
             if description:
                 field.description = str(description)
-
-        if is_optional(model_field, django_type.is_input, django_type.is_partial):
-            field.type_annotation.annotation = Optional[field.type_annotation.annotation]
 
     return field
 


### PR DESCRIPTION
I've just copied the `strawberry_django` code where it check if an auto-type should be optional or not.

Since there is no tests on schema, I'm not able to write test for this.

This PR fix #55 

As a side note: I saw a lot of code difference between `strawberry_django` and `strawberry-django-plus` in `type._process_type` and `type.get_fields` methods. I think `strawberry-django-plus` should use more of `strawberry_django` on theses parts