### PR TITLE
fix: allow update of nested input fields on foreign key relationships

### DIFF
--- a/demo/schema.py
+++ b/demo/schema.py
@@ -154,7 +154,7 @@ class TagInputPartial(gql.NodeInputPartial):
 @gql.django.input(Issue)
 class IssueInput:
     name: gql.auto
-    milestone: gql.auto
+    milestone: "MilestoneInputPartial"
     priority: gql.auto
     kind: gql.auto
     tags: Optional[List[gql.NodeInput]]

--- a/strawberry_django_plus/mutations/resolvers.py
+++ b/strawberry_django_plus/mutations/resolvers.py
@@ -289,6 +289,8 @@ def update(info, instance, data, *, full_clean: Union[bool, FullCleanOptions] = 
             # If value is None, that means we should create the model
             if value is None:
                 value = field.related_model._default_manager.create(**value_data)
+            else:
+                update(info, value, value_data, full_clean=full_clean)
 
         for instance in instances:
             update_field(info, instance, field, value)

--- a/tests/data/schema.gql
+++ b/tests/data/schema.gql
@@ -135,7 +135,7 @@ input IssueAssigneePartialListInput {
 
 input IssueInput {
   name: String!
-  milestone: NodeInput
+  milestone: MilestoneInputPartial!
   priority: Int
 
   """the kind of the issue"""
@@ -146,7 +146,7 @@ input IssueInput {
 input IssueInputPartial {
   id: GlobalID!
   name: String
-  milestone: NodeInput
+  milestone: MilestoneInputPartial!
   priority: Int
 
   """the kind of the issue"""

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -374,6 +374,54 @@ def test_input_update_mutation(db, gql_client: GraphQLTestClient):
 
 
 @pytest.mark.django_db(transaction=True)
+def test_input_nested_update_mutation(db, gql_client: GraphQLTestClient):
+    query = """
+    mutation CreateIssue ($input: IssueInputPartial!) {
+      updateIssue (input: $input) {
+        __typename
+        ... on OperationInfo {
+          messages {
+            kind
+            field
+            message
+          }
+        }
+        ... on IssueType {
+          id
+          name
+          milestone {
+            id
+            name
+          }
+          priority
+          kind
+        }
+      }
+    }
+    """
+    issue = IssueFactory.create(
+        name="Old name",
+        milestone=MilestoneFactory.create(),
+        priority=0,
+        kind=Issue.Kind.BUG,
+    )
+    milestone = MilestoneFactory.create()
+
+    res = gql_client.query(
+        query,
+        {
+            "input": {
+                "id": to_base64("IssueType", issue.pk),
+                "name": "New name",
+                "milestone": {"id": to_base64("MilestoneType", milestone.pk), "name": "foo"},
+            }
+        },
+    )
+    assert res.data and isinstance(res.data["updateIssue"], dict)
+    assert res.data["updateIssue"]["milestone"]["name"] == "foo"
+
+
+@pytest.mark.django_db(transaction=True)
 def test_input_update_m2m_set_not_null_mutation(db, gql_client: GraphQLTestClient):
     query = """
     mutation UpdateProject ($input: ProjectInputPartial!) {

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -405,7 +405,7 @@ def test_input_nested_update_mutation(db, gql_client: GraphQLTestClient):
         priority=0,
         kind=Issue.Kind.BUG,
     )
-    milestone = MilestoneFactory.create()
+    milestone = MilestoneFactory.create(name="Something")
 
     res = gql_client.query(
         query,
@@ -419,6 +419,8 @@ def test_input_nested_update_mutation(db, gql_client: GraphQLTestClient):
     )
     assert res.data and isinstance(res.data["updateIssue"], dict)
     assert res.data["updateIssue"]["milestone"]["name"] == "foo"
+    milestone.refresh_from_db()
+    assert milestone.name == "foo"
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
I don't know if that was intentional, bc it seems to work with m2m relationships, but for ForeignKey relationships, at the moment, the related model is not updated, when an id is passed / it already exists. This is somewhat counter-intuitive, this is a proposal to fix this. 

Would this be acceptable? 