### PR TITLE
fix: django connection field resolve_connection args

### DIFF
--- a/strawberry_django_plus/field.py
+++ b/strawberry_django_plus/field.py
@@ -313,7 +313,12 @@ class StrawberryDjangoConnectionField(relay.ConnectionField, StrawberryDjangoFie
         return args
 
     @resolvers.async_safe
-    def resolve_connection(self, *args, **kwargs):
+    def resolve_connection(
+        self,
+        *args,
+        **kwargs,
+    ):
+        kwargs = {k: v for k, v in kwargs.items() if k in self.default_args}
         return super().resolve_connection(*args, **kwargs)
 
 


### PR DESCRIPTION
### Issue
- cannot use info kwargs on resolver function when resolve_connection.

### What situation?
- when i use info on custom connection resolver, it pass info twice
```python
def tasks_resolver(self, info: Info) -> Iterable[Task]:
    # ...do something
    return results

@gql.type
class Query:
    tasks: Connection[Task] = gql.django.connection(
        resolver=tasks_resolver
    )
```

_**fields.py**_
```python
class StrawberryDjangoConnectionField(relay.ConnectionField, StrawberryDjangoField):
    ...
    @resolvers.async_safe
    def resolve_connection(self, *args, **kwargs):
        return super().resolve_connection(*args, **kwargs)
```

```
>>> resolve_connection() got multiple values for argument 'info'
```

### What changed?
- pass kwargs only in `self.default_args`

_**fields.py**_
```python
class StrawberryDjangoConnectionField(relay.ConnectionField, StrawberryDjangoField):
    ...
    @resolvers.async_safe
    def resolve_connection(
            self,
            *args,
            **kwargs,
    ):
        kwargs = {k: v for k, v in kwargs.items() if k in self.default_args}
        return super().resolve_connection(*args, **kwargs)
```