### PR TITLE
fix handling of strawberry.Private (lazy)

### DIFF
--- a/strawberry_django_plus/type.py
+++ b/strawberry_django_plus/type.py
@@ -1,3 +1,4 @@
+from contextlib import suppress
 import dataclasses
 import types
 from typing import (
@@ -204,14 +205,12 @@ def _get_fields(django_type: "StrawberryDjangoType"):
 
     # collect all annotated fields
     for name, annotation in get_annotations(origin).items():
-        try:
+        with suppress(PrivateStrawberryFieldError):
             fields[name] = _from_django_type(
                 django_type,
                 name,
                 type_annotation=annotation,
             )
-        except PrivateStrawberryFieldError:
-            pass
         seen_fields.add(name)
 
     # collect non-annotated strawberry fields

--- a/strawberry_django_plus/type.py
+++ b/strawberry_django_plus/type.py
@@ -200,6 +200,7 @@ def _from_django_type(
 def _get_fields(django_type: "StrawberryDjangoType"):
     origin = django_type.origin
     fields = {}
+    seen_fields = set()
 
     # collect all annotated fields
     for name, annotation in get_annotations(origin).items():
@@ -211,10 +212,11 @@ def _get_fields(django_type: "StrawberryDjangoType"):
             )
         except PrivateStrawberryFieldError:
             pass
+        seen_fields.add(name)
 
     # collect non-annotated strawberry fields
     for name in dir(origin):
-        if name in fields:
+        if name in seen_fields:
             continue
 
         attr = getattr(origin, name, None)

--- a/strawberry_django_plus/type.py
+++ b/strawberry_django_plus/type.py
@@ -20,11 +20,11 @@ from django.db.models.fields.reverse_related import ManyToManyRel, ManyToOneRel
 import strawberry
 from strawberry import UNSET
 from strawberry.annotation import StrawberryAnnotation
-from strawberry.field import UNRESOLVED, StrawberryField
-from strawberry.types.fields.resolver import StrawberryResolver
 from strawberry.exceptions import PrivateStrawberryFieldError
-from strawberry.unset import UnsetType
+from strawberry.field import UNRESOLVED, StrawberryField
 from strawberry.private import is_private
+from strawberry.types.fields.resolver import StrawberryResolver
+from strawberry.unset import UnsetType
 from strawberry.utils.typing import __dataclass_transform__
 from strawberry_django.fields.field import field as _field
 from strawberry_django.fields.types import get_model_field, resolve_model_field_name


### PR DESCRIPTION
Fixes #118

Reason:
for the lazy annotation to work, we have to remove `from __future__ import annotations`
which stringifies the strawberry.Private, which causes it to be handled correctly accidentally.

Here we check for private fields and throw and exception which is captured and the field not entered.

Note: strawberry-django has likely similar problems