### PR TITLE
Make Connection.from_nodes async_safe

### DIFF
--- a/strawberry_django_plus/relay.py
+++ b/strawberry_django_plus/relay.py
@@ -53,7 +53,7 @@ from strawberry.utils.str_converters import to_camel_case
 from typing_extensions import Annotated
 
 from .settings import config
-from .utils import aio
+from .utils import aio, resolvers
 
 __all__ = [
     "Connection",
@@ -601,6 +601,7 @@ class Connection(Generic[NodeType]):
     )
 
     @classmethod
+    @resolvers.async_safe
     def from_nodes(
         cls,
         nodes: Iterable[NodeType],


### PR DESCRIPTION
Resolves #176

I'm not sure it's safe to be marked as `@async_safe`.