### PR TITLE
Bump strawberry-graphql to 0.161.0 and fix import error

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1466,14 +1466,14 @@ tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
 name = "strawberry-graphql"
-version = "0.160.0"
+version = "0.161.0"
 description = "A library for creating GraphQL APIs"
 category = "main"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "strawberry_graphql-0.160.0-py3-none-any.whl", hash = "sha256:b2b7c114a9d36ceb9c7d11e54ebaa9fbdf72d629e061bb04b224ab9d75276939"},
-    {file = "strawberry_graphql-0.160.0.tar.gz", hash = "sha256:d84f0b3e11c9c54e510529910e1e8dbd93d09026f0989d2e33375f863f8180f0"},
+    {file = "strawberry_graphql-0.161.0-py3-none-any.whl", hash = "sha256:593ece8c40e593132995f886e244c8263828a385fc1df6eb1138a3dd8b9cc169"},
+    {file = "strawberry_graphql-0.161.0.tar.gz", hash = "sha256:e01e5f52aade245aeb3c66a7b179ab49be7f6f6e6ce5974d68a83497d8cf569d"},
 ]
 
 [package.dependencies]
@@ -1657,4 +1657,4 @@ enum = ["django-choices-field"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "37f31fbe76363d47cff8e313063dbd6d59b7df2b6b2ec146bc5bde3074b962a5"
+content-hash = "9eb363856628104c4acb90fc5a5ced45f5c2d8d7b1cb871b400cdde4fdc0ec85"

--- a/poetry.lock
+++ b/poetry.lock
@@ -289,7 +289,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
     {file = "codecov-2.1.12-py2.py3-none-any.whl", hash = "sha256:585dc217dc3d8185198ceb402f85d5cb5dbfa0c5f350a5abcdf9e347776a5b47"},
-    {file = "codecov-2.1.12-py3.8.egg", hash = "sha256:782a8e5352f22593cbc5427a35320b99490eb24d9dcfa2155fd99d2b75cfb635"},
     {file = "codecov-2.1.12.tar.gz", hash = "sha256:a0da46bb5025426da895af90938def8ee12d37fcbcbbbc15b6dc64cf7ebc51c1"},
 ]
 
@@ -1224,6 +1223,13 @@ files = [
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
     {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
     {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
+    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
+    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
     {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
@@ -1460,14 +1466,14 @@ tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
 name = "strawberry-graphql"
-version = "0.159.0"
+version = "0.160.0"
 description = "A library for creating GraphQL APIs"
 category = "main"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "strawberry_graphql-0.159.0-py3-none-any.whl", hash = "sha256:459890ef2f4afb89fc6b13fc24e2453db1904ac37bc85a08990814c19ef06ee2"},
-    {file = "strawberry_graphql-0.159.0.tar.gz", hash = "sha256:0650b2a398457981f4a3ae139336f26c1c1bdda3a18118bc84ecb68edc45b663"},
+    {file = "strawberry_graphql-0.160.0-py3-none-any.whl", hash = "sha256:b2b7c114a9d36ceb9c7d11e54ebaa9fbdf72d629e061bb04b224ab9d75276939"},
+    {file = "strawberry_graphql-0.160.0.tar.gz", hash = "sha256:d84f0b3e11c9c54e510529910e1e8dbd93d09026f0989d2e33375f863f8180f0"},
 ]
 
 [package.dependencies]
@@ -1651,4 +1657,4 @@ enum = ["django-choices-field"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "eaee829c2af0a6b80ed475fcbe82b15289b38ad286a1ec52da2af9e499b6eca3"
+content-hash = "37f31fbe76363d47cff8e313063dbd6d59b7df2b6b2ec146bc5bde3074b962a5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ include = ["strawberry_django_plus/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.8"
 django = ">= 3.2"
-strawberry-graphql = ">= 0.140.3"
+strawberry-graphql = ">=0.140.3"
 strawberry-graphql-django = ">= 0.8"
 typing-extensions = ">= 4.2.0"
 django-debug-toolbar = { version = ">=3.4", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ include = ["strawberry_django_plus/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.8"
 django = ">= 3.2"
-strawberry-graphql = ">=0.140.3"
+strawberry-graphql = ">=0.161.0"
 strawberry-graphql-django = ">= 0.8"
 typing-extensions = ">= 4.2.0"
 django-debug-toolbar = { version = ">=3.4", optional = true }

--- a/strawberry_django_plus/directives.py
+++ b/strawberry_django_plus/directives.py
@@ -25,7 +25,7 @@ from graphql.type.definition import (
     GraphQLUnionType,
     GraphQLWrappingType,
 )
-from strawberry.extensions.base_extension import Extension
+from strawberry.extensions import SchemaExtension
 from strawberry.field import StrawberryField
 from strawberry.private import Private
 from strawberry.schema.schema import Schema
@@ -98,7 +98,7 @@ class SchemaDirectiveHelper:
     is_list: bool
 
 
-class SchemaDirectiveExtension(Extension):
+class SchemaDirectiveExtension(SchemaExtension):
     """Execute schema directives."""
 
     _helper_cache: ClassVar[Dict[Tuple[str, str], SchemaDirectiveHelper]] = {}

--- a/strawberry_django_plus/optimizer.py
+++ b/strawberry_django_plus/optimizer.py
@@ -27,7 +27,7 @@ from django.db.models.manager import BaseManager
 from django.db.models.query import QuerySet
 from graphql.language.ast import OperationType
 from graphql.type.definition import GraphQLResolveInfo, get_named_type
-from strawberry.extensions.base_extension import Extension
+from strawberry.extensions import SchemaExtension
 from strawberry.lazy_type import LazyType
 from strawberry.schema.schema import Schema
 from strawberry.types.execution import ExecutionContext
@@ -546,7 +546,7 @@ optimizer: contextvars.ContextVar[Optional["DjangoOptimizerExtension"]] = contex
 )
 
 
-class DjangoOptimizerExtension(Extension):
+class DjangoOptimizerExtension(SchemaExtension):
     """Automatically optimize returned querysets from internal resolvers.
 
     Attributes


### PR DESCRIPTION
[Strawberry 0.160.0](https://github.com/strawberry-graphql/strawberry/blob/main/CHANGELOG.md#01600---2023-03-08) removes `Extension` from `strawberry.extensions.base_extension`.

I've fixed the import errors, as well as bumped the version number in `poetry.lock` by running `poetry add "strawberry-graphql>= 0.161.0"`.