### PR TITLE
Prevent replacing formatting characters if params is None

### DIFF
--- a/strawberry_django_plus/mutations/fields.py
+++ b/strawberry_django_plus/mutations/fields.py
@@ -70,9 +70,12 @@ def _get_validation_errors(error: Exception):
     elif isinstance(error, ValidationError) and hasattr(error, "error_list"):
         # convert non-field errors
         for e in error.error_list:
+            message = e.message
+            if e.params:
+                message %= e.params
             yield OperationMessage(
                 kind=kind,
-                message=e.message % e.params,
+                message=message,
             )
     else:
         msg = getattr(error, "msg", None)


### PR DESCRIPTION
There's something I overlooked in my previous PR #199. That is that ValidationError.params can be None. If params is None, you get an error like this.
<img src="https://user-images.githubusercontent.com/33048431/234503196-2f8434d6-7c92-4ece-a891-0ec227188601.png" width="512">

So I took the code from the Django official repository and modified it to not apply if params is None.
https://github.com/django/django/blob/18a7f2c711529f8e43c36190a5e2479f13899749/django/core/exceptions.py#L206-L209

I apologize for the hassle. 😖