### PR TITLE
Support custom QS for prefetches

### DIFF
--- a/strawberry_django_plus/optimizer.py
+++ b/strawberry_django_plus/optimizer.py
@@ -87,11 +87,13 @@ def _get_prefetch_queryset(
     """
     if not config.prefetch_custom_queryset:
         return remote_model._base_manager.all()
-    remote_type_def = typing.get_args(field.type_annotation.annotation)
-    if type(remote_type_def) is ForwardRef:
-        remote_type = eval_type(remote_type_def, field.type_annotation.namespace, None)
+    remote_type_defs = typing.get_args(field.type_annotation.annotation)
+    if len(remote_type_defs) != 1:
+        raise TypeError(f"Expected exactly one remote type: {remote_type_defs}")
+    if type(remote_type_defs[0]) is ForwardRef:
+        remote_type = eval_type(remote_type_defs[0], field.type_annotation.namespace, None)
     else:
-        remote_type = remote_type_def
+        remote_type = remote_type_defs[0]
     return remote_type.get_queryset(remote_model.objects.all(), info)
 
 

--- a/strawberry_django_plus/optimizer.py
+++ b/strawberry_django_plus/optimizer.py
@@ -75,9 +75,9 @@ PrefetchType: TypeAlias = Union[str, Prefetch, PrefetchCallable]
 
 
 def _get_prefetch_queryset(
-    remote_model: models.Model,
+    remote_model: Type[models.Model],
     field,
-    config: "OptimizerConfig",
+    config: Optional["OptimizerConfig"],
     info: GraphQLResolveInfo,
 ) -> QuerySet:
     """Returns a model's original QuerySet or a user's specified one.
@@ -85,8 +85,8 @@ def _get_prefetch_queryset(
     If config.prefetch_custom_queryset is set True, the type's get_queryset() as well as
     the model's custom manager/queryset are used to generate the prefetch query.
     """
-    if not config.prefetch_custom_queryset:
-        return remote_model._base_manager.all()
+    if not config or not config.prefetch_custom_queryset:
+        return remote_model._base_manager.all()  # type: ignore
     remote_type_defs = typing.get_args(field.type_annotation.annotation)
     if len(remote_type_defs) != 1:
         raise TypeError(f"Expected exactly one remote type: {remote_type_defs}")


### PR DESCRIPTION
Why:

- Repect the filters applied by get_queryset used in Django types

This change addresses the need by:

- Adding the option to keep the existing prefetch behavior
- Or prefetch witha the user's get_queryset and custom model manager