### PR TITLE
__dataclass_transform__ has been removed from strawberry-graphql

### DIFF
--- a/strawberry_django_plus/filters.py
+++ b/strawberry_django_plus/filters.py
@@ -5,10 +5,11 @@ from django.db.models.base import Model
 from django.db.models.sql.query import get_field_names_from_opts  # type: ignore
 from strawberry import UNSET
 from strawberry.field import StrawberryField
-from strawberry.utils.typing import __dataclass_transform__
 from strawberry_django import filters as _filters
 from strawberry_django import utils
 from strawberry_django.fields.field import field as _field
+
+from typing_extensions import dataclass_transform
 
 from . import field
 from .relay import GlobalID, connection, node
@@ -69,9 +70,9 @@ def _build_filter_kwargs(filters):
 _filters.build_filter_kwargs = _build_filter_kwargs
 
 
-@__dataclass_transform__(
+@dataclass_transform(
     order_default=True,
-    field_descriptors=(
+    field_specifiers=(
         StrawberryField,
         _field,
         node,

--- a/strawberry_django_plus/ordering.py
+++ b/strawberry_django_plus/ordering.py
@@ -4,11 +4,12 @@ import strawberry
 from django.db.models.base import Model
 from strawberry import UNSET
 from strawberry.field import StrawberryField
-from strawberry.utils.typing import __dataclass_transform__
 from strawberry_django.fields.field import field as _field
 from strawberry_django.ordering import Ordering
 
 from strawberry_django_plus.utils.typing import is_auto
+
+from typing_extensions import dataclass_transform
 
 from . import field
 from .relay import connection, node
@@ -16,9 +17,9 @@ from .relay import connection, node
 _T = TypeVar("_T")
 
 
-@__dataclass_transform__(
+@dataclass_transform(
     order_default=True,
-    field_descriptors=(
+    field_specifiers=(
         StrawberryField,
         _field,
         node,

--- a/strawberry_django_plus/type.py
+++ b/strawberry_django_plus/type.py
@@ -30,12 +30,12 @@ from strawberry.private import is_private
 from strawberry.types import Info
 from strawberry.types.fields.resolver import StrawberryResolver
 from strawberry.unset import UnsetType
-from strawberry.utils.typing import __dataclass_transform__, eval_type
+from strawberry.utils.typing import eval_type
 from strawberry_django.fields.field import field as _field
 from strawberry_django.fields.types import get_model_field, resolve_model_field_name
 from strawberry_django.type import StrawberryDjangoType as _StraberryDjangoType
 from strawberry_django.utils import get_annotations, is_similar_django_type
-from typing_extensions import Annotated
+from typing_extensions import Annotated, dataclass_transform
 
 from strawberry_django_plus.optimizer import OptimizerStore, PrefetchType
 from strawberry_django_plus.utils.typing import TypeOrSequence, is_auto
@@ -362,9 +362,9 @@ class StrawberryDjangoType(_StraberryDjangoType[_O, _M]):
     store: OptimizerStore
 
 
-@__dataclass_transform__(
+@dataclass_transform(
     order_default=True,
-    field_descriptors=(
+    field_specifiers=(
         StrawberryField,
         _field,
         node,
@@ -429,9 +429,9 @@ def type(  # noqa: A001
     return wrapper
 
 
-@__dataclass_transform__(
+@dataclass_transform(
     order_default=True,
-    field_descriptors=(
+    field_specifiers=(
         StrawberryField,
         _field,
         node,
@@ -475,9 +475,9 @@ def interface(
     return wrapper
 
 
-@__dataclass_transform__(
+@dataclass_transform(
     order_default=True,
-    field_descriptors=(
+    field_specifiers=(
         StrawberryField,
         _field,
         node,
@@ -525,9 +525,9 @@ def input(  # noqa: A001
     return wrapper
 
 
-@__dataclass_transform__(
+@dataclass_transform(
     order_default=True,
-    field_descriptors=(
+    field_specifiers=(
         StrawberryField,
         _field,
         node,


### PR DESCRIPTION
Do not merge this yet! Something isn't quite right.

strawberry-graphql removed their custom ```__dataclass_transform__``` decorator in favor of typing-extensions ```dataclass_transform```.

Following their convention, I have attempted to update this, but there seems to be a difference causing queries to no longer return data.

This will likely fail tests. Queries do not return data.

Any thoughts? 